### PR TITLE
Migrate extensions to inherit from Extension class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # feincms-articles changelog
 
+## v1.0
+
+* Migrate extensions to inherit from ``feincms.extensions.Extension``. Support
+ for ``register(cls, admin_cls)``-style functions is removed in FeinCMS v1.9.
 
 ## v0.4
 

--- a/articles/extensions/location.py
+++ b/articles/extensions/location.py
@@ -3,22 +3,29 @@ import warnings
 from django.contrib.gis import admin
 from django.contrib.gis.db import models
 from django.utils.translation import ugettext_lazy as _
+from feincms import extensions
 
 
-def register(cls, admin_cls):
-    cls.add_to_class('location', models.PointField(verbose_name=_('location'), null=True, blank=True))
+class Extension(extensions.Extension):
+    def handle_model(self):
+        self.model.add_to_class(
+            'location',
+            models.PointField(verbose_name=_('location'), null=True, blank=True))
 
-    from articles.models import ArticleManager
-    class GeoArticleManager(ArticleManager, models.GeoManager):
-        pass
-    cls.add_to_class('objects', GeoArticleManager())
+        from articles.models import ArticleManager
 
-    if admin_cls:
-        if not issubclass(admin_cls, admin.OSMGeoAdmin):
-            warnings.warn("The admin class articles ArticleAdmin class is not a sub class of django.contrib.gis.admin.OSMGeoAdmin. "
-                          "Consider setting ARTICLE_MODELADMIN_CLASS = 'django.contrib.gis.admin.OSMGeoAdmin'")
+        class GeoArticleManager(ArticleManager, models.GeoManager):
+            pass
 
-        admin_cls.add_extension_options(_('Location'), {
+        self.model.add_to_class('objects', GeoArticleManager())
+
+    def handle_modeladmin(self, modeladmin):
+        if not issubclass(modeladmin, admin.OSMGeoAdmin):
+            warnings.warn(
+                "The admin class articles ArticleAdmin class is not a sub class of django.contrib.gis.admin.OSMGeoAdmin. "
+                "Consider setting ARTICLE_MODELADMIN_CLASS = 'django.contrib.gis.admin.OSMGeoAdmin'")
+
+        modeladmin.add_extension_options(_('Location'), {
             'fields': ('location',),
             'classes': ('collapse',),
         })

--- a/articles/extensions/tags.py
+++ b/articles/extensions/tags.py
@@ -1,25 +1,30 @@
 from django.conf.urls.defaults import patterns, url
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
+from feincms import extensions
 
 try:
     from taggit.managers import TaggableManager
 except ImportError:
    raise ImproperlyConfigured('You need to install django-taggit to use the tags extension')
 
-def register(cls, admin_cls):
-    cls.add_to_class('tags', TaggableManager(verbose_name=_('tags'), blank=True))
 
-    cls.get_urlpatterns_orig = cls.get_urlpatterns
-    @classmethod
-    def get_urlpatterns(cls):
-        return cls.get_urlpatterns_orig() + patterns('taggit.views',
-                                                     url(r'^tags/(?P<slug>[^/]+)/$', 'tagged_object_list', {'queryset': cls.objects.active}, name="article_tagged_list"),
-                                                   )
-    cls.get_urlpatterns = get_urlpatterns
+class Extension(extensions.Extension):
+    def handle_model(self):
+        self.model.add_to_class('tags', TaggableManager(verbose_name=_('tags'), blank=True))
+        self.model.get_urlpatterns_orig = self.model.get_urlpatterns
 
-    if admin_cls:
-        admin_cls.add_extension_options(_('Tags'), {
+        @classmethod
+        def get_urlpatterns(cls):
+            taggit_patterns = patterns('taggit.views',
+                url(r'^tags/(?P<slug>[^/]+)/$', 'tagged_object_list', {
+                    'queryset': cls.objects.active}, name="article_tagged_list"
+                ),
+            )
+            return cls.get_urlpatterns_orig() + taggit_patterns
+        self.model.get_urlpatterns = get_urlpatterns
+
+    def handle_modeladmin(self, modeladmin):
+        modeladmin.add_extension_options(_('Tags'), {
             'fields': ('tags',),
         })
-

--- a/articles/extensions/thumbnail.py
+++ b/articles/extensions/thumbnail.py
@@ -1,11 +1,21 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from feincms import extensions
 
-def register(cls, admin_cls):
-    cls.add_to_class('thumbnail', models.ImageField(_('thumbnail'), max_length=250, upload_to="images/articles/thumbnails", null=True, blank=True))
-    if admin_cls:
-        admin_cls.add_extension_options(_('Thumbnail'), {
+
+class Extension(extensions.Extension):
+    def handle_model(self):
+        self.model.add_to_class(
+            'thumbnail',
+            models.ImageField(
+                _('thumbnail'),
+                max_length=250,
+                upload_to="images/articles/thumbnails",
+                null=True,
+                blank=True)
+        )
+
+    def handle_modeladmin(self, modeladmin):
+        modeladmin.add_extension_options(_('Thumbnail'), {
             'fields': ('thumbnail',),
         })
-
-

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'django-mptt',
         'django-pagination',
     ],
-    version='0.4',
+    version='1.0',
     description='Provides Articles using (FeinCMS content) with categories and tags.',
     author='Incuna Ltd',
     author_email='admin@incuna.com',


### PR DESCRIPTION
Support for `register(cls, admin_cls)`-style functions is removed in
FeinCMS v1.9.
