### PR TITLE
Support **kwargs in index_queryset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # feincms-articles changelog
 
+## Upcoming
+
+* Allow for `using` keyword argument in `ArticleIndex.index_queryset`.
+
 ## 1.2
 
 * remove `patterns` in url.

--- a/articles/search_indexes.py
+++ b/articles/search_indexes.py
@@ -12,7 +12,7 @@ class TempArticleIndex(indexes.SearchIndex):
     def get_model(self):
         return Article
 
-    def index_queryset(self):
+    def index_queryset(self, **kwargs):
         return self.get_model().objects.active()
 
     def get_updated_field(self, **kwargs):

--- a/articles/search_indexes.py
+++ b/articles/search_indexes.py
@@ -12,7 +12,7 @@ class TempArticleIndex(indexes.SearchIndex):
     def get_model(self):
         return Article
 
-    def index_queryset(self, **kwargs):
+    def index_queryset(self, using=None):
         return self.get_model().objects.active()
 
     def get_updated_field(self, **kwargs):


### PR DESCRIPTION
Running a site using this indexer gives the following error:

>  TypeError: index_queryset() got an unexpected keyword argument 'using'

We need to add `using=None` or `**kwargs` to `index_queryset` to avoid it.

@incuna/backend @maxpeterson review/merge please?